### PR TITLE
Replace GC correction and skip steps when result files exist

### DIFF
--- a/DeepSomaticCopy/pipeline.py
+++ b/DeepSomaticCopy/pipeline.py
@@ -124,8 +124,6 @@ def scriptRunEverything():
         stepVal = getValuesSYS(listIn, ['-step'])
         stepVal = stepVal[0]
 
-        
-
         if stepVal == 'processing':
             keyList = ['-input', '-ref', '-output', '-refGenome']
             values1 = getValuesSYS(listIn, keyList)
@@ -133,8 +131,10 @@ def scriptRunEverything():
 
             hist_file = outLoc + '/initial/allHistBam_100k.npz'
             chr_file = outLoc + '/initial/allChr_100k.npz'
-            if os.path.exists(hist_file) and os.path.exists(chr_file):
-                print("Skipping BAM processing beacuse chr_file and hist_file exist")
+            
+            # check for final BAM processing files
+            if all([os.path.exists(outLoc + '/phasedCounts/chr_' + str(chrNum) + '.npz') for chrNum in range(1, 23)]):
+                print("Skipping BAM processing because phased counts exist for all chromosomes")
             else:
                 runAllSteps(bamLoc, refLoc, outLoc, refGenome, useCB=doCB)
             runProcessFull(outLoc, refLoc, refGenome)

--- a/DeepSomaticCopy/pipeline.py
+++ b/DeepSomaticCopy/pipeline.py
@@ -1,4 +1,5 @@
 import sys
+import os
 import numpy as np
 
 from .process import runProcessFull
@@ -130,7 +131,12 @@ def scriptRunEverything():
             values1 = getValuesSYS(listIn, keyList)
             bamLoc, refLoc, outLoc, refGenome = values1[0], values1[1], values1[2], values1[3]
 
-            runAllSteps(bamLoc, refLoc, outLoc, refGenome, useCB=doCB)
+            hist_file = outLoc + '/initial/allHistBam_100k.npz'
+            chr_file = outLoc + '/initial/allChr_100k.npz'
+            if os.path.exists(hist_file) and os.path.exists(chr_file):
+                print("Skipping BAM processing beacuse chr_file and hist_file exist")
+            else:
+                runAllSteps(bamLoc, refLoc, outLoc, refGenome, useCB=doCB)
             runProcessFull(outLoc, refLoc, refGenome)
             scalorRunBins(outLoc)
         

--- a/DeepSomaticCopy/process.py
+++ b/DeepSomaticCopy/process.py
@@ -964,9 +964,13 @@ def modal_quantile_regression(df_regression, lowess_frac=0.2, degree=2, knots=[0
         df_regression['modal_curve'] = df_regression[modal_quantile]
         df_regression['modal_corrected'] = df_regression['reads'] / df_regression[modal_quantile]
 
+        # handle negative or missing values in regions with outlier GC
+        df_regression.modal_corrected = df_regression.modal_corrected.fillna(0)
+        df_regression.loc[df_regression.modal_corrected < 0, 'modal_corrected'] = 1
+
         return df_regression
 
-def findGCadjustment(hist_file, bias_file, goodSubset_file, RDR_file, threads=16):
+def findGCadjustment(hist_file, bias_file, goodSubset_file, RDR_file, threads=24):
     bin_subset = loadnpz(goodSubset_file)
     read_counts = loadnpz(hist_file).T[bin_subset].T
     mappability, gc = loadnpz(bias_file).T

--- a/DeepSomaticCopy/runBAM.py
+++ b/DeepSomaticCopy/runBAM.py
@@ -1338,7 +1338,10 @@ def runAllSteps(bamLoc, refLoc, outLoc, refGenome, useCB=False):
         bamLocNew = '.'.join(bamLocNew)
         bamLocNew = bamLocNew + 'new.' + bamLocNew_end
 
-        fullRenameProcess(bamLoc, bamLocNew, otherSam=otherSam)
+        if os.path.exists(bamLocNew):
+            print('Skipping BAM renaming')
+        else:
+            fullRenameProcess(bamLoc, bamLocNew, otherSam=otherSam)
 
         bamLoc = bamLocNew
 

--- a/DeepSomaticCopy/runBAM.py
+++ b/DeepSomaticCopy/runBAM.py
@@ -1262,7 +1262,7 @@ def findReadCounts(bamLoc, outLoc):
     samfile = pysam.AlignmentFile(bamLoc, "rb")
 
     chrType = 'num'
-    chrName = ''
+    chrName = '1'
     try:
         samfile.fetch(chrName)
     except:

--- a/DeepSomaticCopy/runBAM.py
+++ b/DeepSomaticCopy/runBAM.py
@@ -1329,8 +1329,6 @@ def findReadCounts(bamLoc, outLoc):
 
 def runAllSteps(bamLoc, refLoc, outLoc, refGenome, useCB=False):
 
-
-
     otherSam = False
     if useCB:
         bamLocNew = bamLoc.split('.')
@@ -1345,7 +1343,6 @@ def runAllSteps(bamLoc, refLoc, outLoc, refGenome, useCB=False):
 
         bamLoc = bamLocNew
 
-    
     numSteps = '9'
     stepName = 0
 
@@ -1355,25 +1352,43 @@ def runAllSteps(bamLoc, refLoc, outLoc, refGenome, useCB=False):
     makeAllDirectories(outLoc)
     print ("Done")
 
-    stepName += 1
-    stepString = str(stepName) + '/' + numSteps
-    print ('Data processing — Step ' + stepString + ': Running bcftools on pseudobulk (may take hours to days)... ', end='')
-    findCombinedCounts(bamLoc, refLoc, outLoc, refGenome)
-    print ("Done")
+
+    chroms =  [str(i) for i in range(1, 22+1)]
 
     stepName += 1
     stepString = str(stepName) + '/' + numSteps
-    print ('Data processing — Step ' + stepString + ': Running SHAPE-IT... ', end='')
-    runPhasing(outLoc, refGenome, refLoc)
-    print ("Done")
+    if all([os.path.exists(outLoc + '/counts/ignore_chr' + chrNum + '.vcf.gz') for chrNum in chroms]) and all([os.path.exists(outLoc + '/counts/ignore_chr' + chrNum + '.vcf.gz.tbi') for chrNum in chroms]):
+        print ('Data processing — Step ' + stepString + ': Skipping bcftools on pseudobulk', end='')
+    else:
+        print ('Data processing — Step ' + stepString + ': Running bcftools on pseudobulk (may take hours to days)... ', end='')
+        findCombinedCounts(bamLoc, refLoc, outLoc, refGenome)
+        print ("Done")
 
     stepName += 1
     stepString = str(stepName) + '/' + numSteps
-    print ('Data processing — Step ' + stepString + ': Running bcftools on individual cells... ', end='')
-    findSubsetCounting(outLoc) #This small processing step doesn't require its own step printed in terminal
+    if all([os.path.exists(outLoc + '/phased/phased_chr' + chrNum + '.bcf') for chrNum in chroms]):
+        print ('Data processing — Step ' + stepString + ': Skipping SHAPE-IT', end='')
 
-    findIndividualCounts(bamLoc, refLoc, outLoc, refGenome)
-    print ("Done")
+    else:
+        print ('Data processing — Step ' + stepString + ': Running SHAPE-IT... ', end='')
+        runPhasing(outLoc, refGenome, refLoc)
+        print ("Done")
+
+
+
+    stepName += 1
+    stepString = str(stepName) + '/' + numSteps
+    if all([os.path.exists(outLoc + '/phased/restricted_chr' + chrNum + '.vcf.gz') for chrNum in chroms]):
+        print ('Data processing — Step ' + stepString + ': Skipping findSubsetCounting', end='')
+    else:    
+        print ('Data processing — Step ' + stepString + ': Running findSubsetCounting ', end='')
+        findSubsetCounting(outLoc) #This small processing step doesn't require its own step printed in terminal
+
+    if all([os.path.exists(outLoc + '/counts/seperates_chr' + chrNum + '.vcf.gz') for chrNum in chroms]):
+        print ('Data processing — Step ' + stepString + ': Skipping findIndividualCounts', end='')
+    else:
+        findIndividualCounts(bamLoc, refLoc, outLoc, refGenome)
+        print ("Done")
 
     stepName += 1
     stepString = str(stepName) + '/' + numSteps
@@ -1383,8 +1398,13 @@ def runAllSteps(bamLoc, refLoc, outLoc, refGenome, useCB=False):
 
     stepName += 1
     stepString = str(stepName) + '/' + numSteps
-    print ('Data processing — Step ' + stepString + ': Phasing haplotype blocks... ', end='')
-    runAllHaplotypeCounts(outLoc)
+    if (all([os.path.exists(outLoc + '/counts/allcounts_chr' + chrNum + '.npz') for chrNum in chroms]) and
+        all([os.path.exists(outLoc + '/phasedCounts/barcodes_chr' + chrNum + '.npz') for chrNum in chroms]) and 
+        all([os.path.exists(outLoc + '/phasedCounts/positions_chr' + chrNum + '.npz') for chrNum in chroms])):
+        print ('Data processing — Step ' + stepString + ': Skipping runAllHaplotypeCounts', end='')
+    else:
+        print ('Data processing — Step ' + stepString + ': Phasing haplotype blocks... ', end='')
+        runAllHaplotypeCounts(outLoc)
 
     runAllGroupedEvidenceSVD(outLoc)
     print ('Done')

--- a/DeepSomaticCopy/scaler.py
+++ b/DeepSomaticCopy/scaler.py
@@ -24,7 +24,7 @@ else:
     from .shared import *
 
 from tqdm import tqdm
-
+import os
 
 
 
@@ -2324,6 +2324,9 @@ def saveReformatCSV(outLoc, isNaive=False):
             dataAll.append( [ cellNames[a], posIndexing[b][0], posIndexing[b][1], posIndexing[b][2], int(pred1[a][b][0]), int(pred1[a][b][1])  ] )
     
     dataAll = np.array(dataAll)
+
+    if not os.path.exists(outLoc + '/finalPrediction'):
+        os.makedirs(outLoc + '/finalPrediction')
     if isNaive:
         outFile = outLoc + '/finalPrediction/NaiveCopyPrediction.csv'
     else:

--- a/DeepSomaticCopy/scaler.py
+++ b/DeepSomaticCopy/scaler.py
@@ -2206,7 +2206,8 @@ def findInitialCNA(RDR_file, noise_file, BAF_file, BAF_noise_file, chr_file, div
         minList = []
         arange1 = np.arange(errorList.shape[0])
         min1 = np.min(errorList)
-        while np.min(errorList) < min1 + 1:
+        #while np.min(errorList) < min1 + 1:
+        if True:
             argMin1 = np.argmin(errorList)
             errorList[np.abs(arange1 - argMin1) <= 5] = min1 + 10
             minList.append(argMin1)

--- a/DeepSomaticCopy/scaler.py
+++ b/DeepSomaticCopy/scaler.py
@@ -2206,8 +2206,8 @@ def findInitialCNA(RDR_file, noise_file, BAF_file, BAF_noise_file, chr_file, div
         minList = []
         arange1 = np.arange(errorList.shape[0])
         min1 = np.min(errorList)
-        #while np.min(errorList) < min1 + 1:
-        if True:
+        while np.min(errorList) < min1 + 1:
+            #if True:
             argMin1 = np.argmin(errorList)
             errorList[np.abs(arange1 - argMin1) <= 5] = min1 + 10
             minList.append(argMin1)


### PR DESCRIPTION
Existing GC correction did not adequately handle DLP+ data which suffers from short and heterogeneous read lengths. Replaced existing code with our typical approach which uses modal quantile regression (using a degree-2 B-spline curve with a knot at gc=0.38). This is substantially more expensive but did appear to greatly improve our results.

File checks are a temporary workaround in place of proper modularization, especially of expensive processing steps (BAM processing, phasing, counting, etc.).